### PR TITLE
Extra buffer for midi command windows

### DIFF
--- a/lib/flutter_midi_command_windows.dart
+++ b/lib/flutter_midi_command_windows.dart
@@ -87,10 +87,10 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
       }
 
       print(
-          "HEY: ${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
+          "${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
 
       bool isConnected = _connectedDevices.containsKey(id);
-      print('HEY: found IN at i $i id $id for device $name');
+      //print('found IN at i $i id $id for device $name');
       devices[id] = WindowsMidiDevice(id, name, _rxStreamController,
           _setupStreamController, _midiCB.nativeFunction.address)
         ..addInput(i, inCaps.ref)
@@ -120,7 +120,7 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
       }
 
       print(
-          "HEY: ${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
+         // "${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
 
       if (devices.containsKey(id)) {
         // print('add OUT at i $i id $id for device $name}');
@@ -305,7 +305,7 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
   /// The event contains the raw bytes contained in the MIDI package.
   @override
   Stream<MidiPacket>? get onMidiDataReceived {
-    print('HEY: MIDI DATA RECEIVED ');
+    //print('MIDI DATA RECEIVED ');
     return _rxStream;
   }
 
@@ -386,7 +386,7 @@ final List<int> partialSysExBuffer = [];
 
 void _onMidiData(
     int hMidiIn, int wMsg, int dwInstance, int dwParam1, int dwParam2) {
-  // print('HEY: midi data $hMidiIn, $wMsg, $dwInstance, $dwParam1, $dwParam2');
+  // print('midi data $hMidiIn, $wMsg, $dwInstance, $dwParam1, $dwParam2');
   var sw = Stopwatch()..start();
 
   var dev = FlutterMidiCommandWindows().findMidiDeviceForSource(hMidiIn);
@@ -427,7 +427,7 @@ void _onMidiData(
         //var data = pMidiHdr.ref.lpData
         //    .cast<Uint8>()
         //    .asTypedList(pMidiHdr.ref.dwBytesRecorded);
-        // print('HEY: data in midi command ${data}');
+       
       } else {
         // Decode and log each flag for debugging
         if ((midiHdr.dwFlags & MHDR_PREPARED) != 0) {
@@ -440,7 +440,7 @@ void _onMidiData(
 
       break;
     case MIM_MOREDATA:
-      print("HEY: More data - unhandled!");
+      print("More data - unhandled!");
       break;
     case MIM_ERROR:
       print("Error");

--- a/lib/flutter_midi_command_windows.dart
+++ b/lib/flutter_midi_command_windows.dart
@@ -119,9 +119,6 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
         id = id + " (${deviceOutputs[name]})";
       }
 
-      print(
-         // "${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
-
       if (devices.containsKey(id)) {
         // print('add OUT at i $i id $id for device $name}');
 

--- a/lib/flutter_midi_command_windows.dart
+++ b/lib/flutter_midi_command_windows.dart
@@ -86,8 +86,8 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
         id = id + " (${deviceInputs[name]})";
       }
 
-      print(
-          "${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
+      //print(
+      //    "${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
 
       bool isConnected = _connectedDevices.containsKey(id);
       //print('found IN at i $i id $id for device $name');

--- a/lib/flutter_midi_command_windows.dart
+++ b/lib/flutter_midi_command_windows.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_midi_command_platform_interface/flutter_midi_command_platform_interface.dart';
@@ -12,15 +13,19 @@ import 'package:win32/win32.dart';
 import 'package:flutter_midi_command_windows/device_monitor.dart';
 
 class FlutterMidiCommandWindows extends MidiCommandPlatform {
-  StreamController<MidiPacket> _rxStreamController = StreamController<MidiPacket>.broadcast();
+  StreamController<MidiPacket> _rxStreamController =
+      StreamController<MidiPacket>.broadcast();
   late Stream<MidiPacket> _rxStream;
-  StreamController<String> _setupStreamController = StreamController<String>.broadcast();
+  StreamController<String> _setupStreamController =
+      StreamController<String>.broadcast();
   late Stream<String> _setupStream;
 
-  StreamController<String> _bluetoothStateStreamController = StreamController<String>.broadcast();
+  StreamController<String> _bluetoothStateStreamController =
+      StreamController<String>.broadcast();
   late Stream<String> _bluetoothStateStream;
 
-  Map<String, WindowsMidiDevice> _connectedDevices = Map<String, WindowsMidiDevice>();
+  Map<String, WindowsMidiDevice> _connectedDevices =
+      Map<String, WindowsMidiDevice>();
 
   // BLE Vars
 
@@ -59,7 +64,6 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
   //#region
   @override
   Future<List<MidiDevice>> get devices async {
-
     var devices = Map<String, MidiDevice>();
 
     Pointer<MIDIINCAPS> inCaps = malloc<MIDIINCAPS>();
@@ -82,11 +86,13 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
         id = id + " (${deviceInputs[name]})";
       }
 
-      //  print("${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
+      print(
+          "HEY: ${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
 
       bool isConnected = _connectedDevices.containsKey(id);
-      // print('found IN at i $i id $id for device $name');
-      devices[id] = WindowsMidiDevice(id, name, _rxStreamController, _setupStreamController, _midiCB.nativeFunction.address)
+      print('HEY: found IN at i $i id $id for device $name');
+      devices[id] = WindowsMidiDevice(id, name, _rxStreamController,
+          _setupStreamController, _midiCB.nativeFunction.address)
         ..addInput(i, inCaps.ref)
         ..connected = isConnected;
     }
@@ -103,7 +109,6 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
       var name = outCaps.ref.szPname;
       var id = name;
 
-
       if (!deviceOutputs.containsKey(name)) {
         deviceOutputs[name] = 0;
       } else {
@@ -114,7 +119,8 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
         id = id + " (${deviceOutputs[name]})";
       }
 
-      print("${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
+      print(
+          "HEY: ${id} ${inCaps.ref.wMid} ${inCaps.ref.wPid} ${inCaps.ref.hashCode} ${inCaps.ref.dwSupport}");
 
       if (devices.containsKey(id)) {
         // print('add OUT at i $i id $id for device $name}');
@@ -125,7 +131,8 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
         // print('found OUT at i $i id $id for device $name');
 
         bool isConnected = _connectedDevices.containsKey(id);
-        devices[id] = WindowsMidiDevice(id, name, _rxStreamController, _setupStreamController, _midiCB.nativeFunction.address)
+        devices[id] = WindowsMidiDevice(id, name, _rxStreamController,
+            _setupStreamController, _midiCB.nativeFunction.address)
           ..addOutput(i, outCaps.ref)
           ..connected = isConnected;
       }
@@ -151,8 +158,10 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
     UniversalBle.onScanResult = (result) {
       if (!_discoveredBLEDevices.containsKey(result.deviceId)) {
         if (result.name != null) {
-          debugPrint("${result.name} ${result.deviceId} ${result.manufacturerData}");
-          _discoveredBLEDevices[result.deviceId] = BLEMidiDevice(result.deviceId, result.name!, _rxStreamController);
+          debugPrint(
+              "${result.name} ${result.deviceId} ${result.manufacturerData}");
+          _discoveredBLEDevices[result.deviceId] =
+              BLEMidiDevice(result.deviceId, result.name!, _rxStreamController);
           _setupStreamController.add('deviceAppeared');
         }
       }
@@ -201,8 +210,7 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
   Future<void> startScanningForBluetoothDevices() async {
     try {
       await UniversalBle.startScan(
-        scanFilter: ScanFilter(withServices: [MIDI_SERVICE_ID])
-      );
+          scanFilter: ScanFilter(withServices: [MIDI_SERVICE_ID]));
     } catch (e) {
       print(e.toString());
     }
@@ -216,7 +224,8 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
 
   /// Connects to the device.
   @override
-  Future<void> connectToDevice(MidiDevice device, {List<MidiPort>? ports}) async {
+  Future<void> connectToDevice(MidiDevice device,
+      {List<MidiPort>? ports}) async {
     if (device is WindowsMidiDevice) {
       var success = device.connect();
       if (success) {
@@ -272,7 +281,9 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
       // Send to specific device, if present
       _connectedDevices[deviceId]?.send(data);
 
-      _discoveredBLEDevices.values.where((element) => element.deviceId == deviceId).forEach((element) {
+      _discoveredBLEDevices.values
+          .where((element) => element.deviceId == deviceId)
+          .forEach((element) {
         element.send(data);
       });
     } else {
@@ -281,7 +292,9 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
         device.send(data);
       });
 
-      _discoveredBLEDevices.values.where((element) => element.connected).forEach((element) {
+      _discoveredBLEDevices.values
+          .where((element) => element.connected)
+          .forEach((element) {
         element.send(data);
       });
     }
@@ -292,6 +305,7 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
   /// The event contains the raw bytes contained in the MIDI package.
   @override
   Stream<MidiPacket>? get onMidiDataReceived {
+    print('HEY: MIDI DATA RECEIVED ');
     return _rxStream;
   }
 
@@ -361,12 +375,23 @@ String midiErrorMessage(int status) {
   }
 }
 
-NativeCallable<Void Function(IntPtr, Uint32, IntPtr, IntPtr, IntPtr)> _midiCB = NativeCallable<MIDIINPROC>.listener(_onMidiData);
+NativeCallable<Void Function(IntPtr, Uint32, IntPtr, IntPtr, IntPtr)> _midiCB =
+    NativeCallable<MIDIINPROC>.listener(_onMidiData);
 
-void _onMidiData(int hMidiIn, int wMsg, int dwInstance, int dwParam1, int dwParam2) {
-  //print('midi data $hMidiIn, $wMsg, $dwInstance, $dwParam1, $dwParam2');
+const int MHDR_DONE = 0x00000001;
+const int MHDR_PREPARED = 0x00000002;
+const int MHDR_INQUEUE = 0x00000004;
+
+final List<int> partialSysExBuffer = [];
+
+void _onMidiData(
+    int hMidiIn, int wMsg, int dwInstance, int dwParam1, int dwParam2) {
+  // print('HEY: midi data $hMidiIn, $wMsg, $dwInstance, $dwParam1, $dwParam2');
+  var sw = Stopwatch()..start();
 
   var dev = FlutterMidiCommandWindows().findMidiDeviceForSource(hMidiIn);
+  final midiHdrPointer = Pointer<MIDIHDR>.fromAddress(dwParam1);
+  final midiHdr = midiHdrPointer.ref;
 
   switch (wMsg) {
     case MIM_OPEN:
@@ -381,12 +406,41 @@ void _onMidiData(int hMidiIn, int wMsg, int dwInstance, int dwParam1, int dwPara
       dev?.handleData(data, dwParam2);
       break;
     case MIM_LONGDATA:
-      var pMidiHdr = Pointer.fromAddress(dwParam1).cast<MIDIHDR>();
-      var data = pMidiHdr.ref.lpData.cast<Uint8>().asTypedList(pMidiHdr.ref.dwBytesRecorded);
-      dev?.handleSysexData(data);
+      if ((midiHdr.dwFlags & MHDR_DONE) != 0) {
+
+        final dataPointer = midiHdr.lpData.cast<Uint8>();
+        final messageData = dataPointer.asTypedList(midiHdr.dwBytesRecorded);
+
+        if (messageData.isNotEmpty && messageData.first == 0xF0) {
+          partialSysExBuffer.clear();
+        }
+
+        partialSysExBuffer.addAll(messageData);
+
+        if (partialSysExBuffer.isNotEmpty && partialSysExBuffer.last == 0xF7) {
+          dev?.handleSysexData(messageData, midiHdrPointer);
+          partialSysExBuffer.clear();
+        }
+
+        //var pMidiHdr = Pointer.fromAddress(dwParam1).cast<MIDIHDR>();
+
+        //var data = pMidiHdr.ref.lpData
+        //    .cast<Uint8>()
+        //    .asTypedList(pMidiHdr.ref.dwBytesRecorded);
+        // print('HEY: data in midi command ${data}');
+      } else {
+        // Decode and log each flag for debugging
+        if ((midiHdr.dwFlags & MHDR_PREPARED) != 0) {
+          print('MHDR_PREPARED is set');
+        }
+        if ((midiHdr.dwFlags & MHDR_INQUEUE) != 0) {
+          print('MHDR_INQUEUE is set');
+        }
+      }
+
       break;
     case MIM_MOREDATA:
-      print("More data - unhandled!");
+      print("HEY: More data - unhandled!");
       break;
     case MIM_ERROR:
       print("Error");

--- a/lib/windows_midi_device.dart
+++ b/lib/windows_midi_device.dart
@@ -189,12 +189,12 @@ class WindowsMidiDevice extends MidiDevice {
   }
 
   handleData(Uint8List data, int timestamp) {
-    print('handle data $data');
+   // print('handle data $data');
     _rxStreamCtrl.add(MidiPacket(data, timestamp, this));
   }
 
   handleSysexData(Uint8List data, Pointer<MIDIHDR> midiHdrPointer) {
-     print('handle SysEX: $data');
+    // print('handle SysEX: $data');
     _rxStreamCtrl.add(MidiPacket(data, 0, this));
     _resetHeader(midiHdrPointer);
   }

--- a/lib/windows_midi_device.dart
+++ b/lib/windows_midi_device.dart
@@ -68,34 +68,34 @@ class WindowsMidiDevice extends MidiDevice {
         result = midiInPrepareHeader(
             hMidiInDevicePtr.value, _midiInHeader, sizeOf<MIDIHDR>());
         if (result != 0) {
-          print("HEY: HDR PREP ERROR: ${midiErrorMessage(result)}");
+          print("HDR PREP ERROR: ${midiErrorMessage(result)}");
           return false;
         }
 
         result = midiInPrepareHeader(
             hMidiInDevicePtr.value, _midiInHeader2, sizeOf<MIDIHDR>());
         if (result != 0) {
-          print("HEY: HDR PREP ERROR: ${midiErrorMessage(result)}");
+          print("HDR PREP ERROR: ${midiErrorMessage(result)}");
           return false;
         }
 
         result = midiInAddBuffer(
             hMidiInDevicePtr.value, _midiInHeader, sizeOf<MIDIHDR>());
         if (result != 0) {
-          print("HEY: HDR ADD ERROR: ${midiErrorMessage(result)}");
+          print("HDR ADD ERROR: ${midiErrorMessage(result)}");
           return false;
         }
 
         result = midiInAddBuffer(
             hMidiInDevicePtr.value, _midiInHeader2, sizeOf<MIDIHDR>());
         if (result != 0) {
-          print("HEY: HDR ADD ERROR: ${midiErrorMessage(result)}");
+          print("HDR ADD ERROR: ${midiErrorMessage(result)}");
           return false;
         }
 
         result = midiInStart(hMidiInDevicePtr.value);
         if (result != 0) {
-          print("HEY: START ERROR: ${midiErrorMessage(result)}");
+          print("START ERROR: ${midiErrorMessage(result)}");
           return false;
         }
       }
@@ -109,7 +109,7 @@ class WindowsMidiDevice extends MidiDevice {
       int result = midiOutOpen(
           hMidiOutDevicePtr, id, 0, 0, MIDI_WAVE_OPEN_TYPE.CALLBACK_NULL);
       if (result != 0) {
-        print("HEY: OUT OPEN ERROR: result");
+        print("OUT OPEN ERROR: result");
         return false;
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_windows
 description: FlutterMidiCommand for windows.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_midi_command_platform_interface: ^0.4.0
   ffi: ^2.1.0
-  win32: ^5.5.1
+  win32: ^5.5.0
   universal_ble: ^0.9.11
 
 dev_dependencies:


### PR DESCRIPTION
There was an issue when multiple SysEx messages came in in very quick succession. 
A second buffer has been added which ensures that messages that come in while the first buffer is still processing, still get processed. The buffer is then re-added to the midi device, making it available again for new data.

Partial messages are also handled.

