### PR TITLE
Feature/upgrade win32 to v6.2.0

### DIFF
--- a/lib/flutter_midi_command_windows.dart
+++ b/lib/flutter_midi_command_windows.dart
@@ -381,7 +381,7 @@ String midiErrorMessage(int status) {
 }
 
 NativeCallable<Void Function(IntPtr, Uint32, IntPtr, IntPtr, IntPtr)> _midiCB =
-    NativeCallable<MIDIINPROC>.listener(_onMidiData);
+    NativeCallable<Void Function(IntPtr, Uint32, IntPtr, IntPtr, IntPtr)>.listener(_onMidiData);
 
 const int MHDR_DONE = 0x00000001;
 const int MHDR_PREPARED = 0x00000002;

--- a/lib/windows_midi_device.dart
+++ b/lib/windows_midi_device.dart
@@ -18,8 +18,8 @@ class WindowsMidiDevice extends MidiDevice {
   StreamController<MidiPacket> _rxStreamCtrl;
   StreamController<String> _setupStreamController;
 
-  final hMidiInDevicePtr = malloc<IntPtr>();
-  final hMidiOutDevicePtr = malloc<IntPtr>();
+  final hMidiInDevicePtr = malloc<Pointer>();
+  final hMidiOutDevicePtr = malloc<Pointer>();
 
   int callbackAddress;
 
@@ -44,11 +44,12 @@ class WindowsMidiDevice extends MidiDevice {
     if (mIn != null) {
       var id = mIn.key;
       int result = midiInOpen(
-          hMidiInDevicePtr as Pointer<Pointer>, id, callbackAddress, 0, CALLBACK_FUNCTION);
+          hMidiInDevicePtr, id, callbackAddress, 0, CALLBACK_FUNCTION);
       if (result != 0) {
         print("OPEN ERROR($result): ${midiErrorMessage(result)}");
         return false;
       } else {
+        print("IN OPEN SUCCESS");
         // Setup buffer
         for (int i = 0; i < _numberOfBuffers; i++) {
           _midiInBuffers[i] = malloc<BYTE>(_bufferSize);
@@ -86,10 +87,13 @@ class WindowsMidiDevice extends MidiDevice {
     if (mOut != null) {
       var id = mOut.key;
 
-      int result = midiOutOpen(hMidiOutDevicePtr  as Pointer<Pointer>, id, 0, 0, CALLBACK_NULL);
+      int result = midiOutOpen(hMidiOutDevicePtr, id, 0, 0, CALLBACK_NULL);
       if (result != 0) {
         print("OUT OPEN ERROR: result");
         return false;
+      }
+      else {
+        print("OUT OPEN SUCCESS");
       }
 
       _midiOutBuffer = malloc<BYTE>(_bufferSize);
@@ -192,6 +196,9 @@ class WindowsMidiDevice extends MidiDevice {
         hMidiOutDevicePtr.value as HMIDIOUT, _midiOutHeader, sizeOf<MIDIHDR>());
     if (result != 0) {
       print("SEND ERROR($result): ${midiErrorMessage(result)}");
+    }
+    else {
+      print("SEND SUCCESS ${data.length} bytes");
     }
 
     result = midiOutUnprepareHeader(

--- a/lib/windows_midi_device.dart
+++ b/lib/windows_midi_device.dart
@@ -18,7 +18,7 @@ class WindowsMidiDevice extends MidiDevice {
   StreamController<MidiPacket> _rxStreamCtrl;
   StreamController<String> _setupStreamController;
 
-  final hMidiInDevicePtr = malloc<HMIDIIN>();
+  final hMidiInDevicePtr = malloc<IntPtr>();
   final hMidiOutDevicePtr = malloc<IntPtr>();
 
   int callbackAddress;
@@ -44,7 +44,7 @@ class WindowsMidiDevice extends MidiDevice {
     if (mIn != null) {
       var id = mIn.key;
       int result = midiInOpen(
-          hMidiInDevicePtr, id, callbackAddress, 0, CALLBACK_FUNCTION);
+          hMidiInDevicePtr as Pointer<Pointer>, id, callbackAddress, 0, CALLBACK_FUNCTION);
       if (result != 0) {
         print("OPEN ERROR($result): ${midiErrorMessage(result)}");
         return false;
@@ -53,27 +53,27 @@ class WindowsMidiDevice extends MidiDevice {
         for (int i = 0; i < _numberOfBuffers; i++) {
           _midiInBuffers[i] = malloc<BYTE>(_bufferSize);
           _midiInHeaders[i] = malloc<MIDIHDR>();
-          _midiInHeaders[i].ref.lpData = _midiInBuffers[i] as LPSTR;
+          _midiInHeaders[i].ref.lpData = _midiInBuffers[i] as PSTR;
           _midiInHeaders[i].ref.dwBufferLength = _bufferSize;
           _midiInHeaders[i].ref.dwFlags = 0;
           _midiInHeaders[i].ref.dwBytesRecorded = 0;
 
           result = midiInPrepareHeader(
-              hMidiInDevicePtr.value, _midiInHeaders[i], sizeOf<MIDIHDR>());
+              hMidiInDevicePtr.value as HMIDIIN, _midiInHeaders[i], sizeOf<MIDIHDR>());
           if (result != 0) {
             print("HDR PREP ERROR: ${midiErrorMessage(result)}");
             return false;
           }
 
           result = midiInAddBuffer(
-              hMidiInDevicePtr.value, _midiInHeaders[i], sizeOf<MIDIHDR>());
+              hMidiInDevicePtr.value as HMIDIIN, _midiInHeaders[i], sizeOf<MIDIHDR>());
           if (result != 0) {
             print("HDR ADD ERROR: ${midiErrorMessage(result)}");
             return false;
           }
         }
 
-        result = midiInStart(hMidiInDevicePtr.value);
+        result = midiInStart(hMidiInDevicePtr.value as HMIDIIN);
         if (result != 0) {
           print("START ERROR: ${midiErrorMessage(result)}");
           return false;
@@ -86,7 +86,7 @@ class WindowsMidiDevice extends MidiDevice {
     if (mOut != null) {
       var id = mOut.key;
 
-      int result = midiOutOpen(hMidiOutDevicePtr, id, 0, 0, CALLBACK_NULL);
+      int result = midiOutOpen(hMidiOutDevicePtr  as Pointer<Pointer>, id, 0, 0, CALLBACK_NULL);
       if (result != 0) {
         print("OUT OPEN ERROR: result");
         return false;
@@ -103,7 +103,7 @@ class WindowsMidiDevice extends MidiDevice {
   bool disconnect() {
     int result;
     if (_ins.length > 0) {
-      result = midiInReset(hMidiInDevicePtr.value);
+      result = midiInReset(hMidiInDevicePtr.value as HMIDIIN);
       if (result != 0) {
         print("RESET ERROR($result): ${midiErrorMessage(result)}");
       }
@@ -111,7 +111,7 @@ class WindowsMidiDevice extends MidiDevice {
       for (int i=0; i < _numberOfBuffers; i++) {
         if (_midiInHeaders[i] != nullptr) {
           midiInUnprepareHeader(
-              hMidiInDevicePtr.value, _midiInHeaders[i], sizeOf<MIDIHDR>());
+              hMidiInDevicePtr.value as HMIDIIN, _midiInHeaders[i], sizeOf<MIDIHDR>());
           free(_midiInHeaders[i]);
         }
         if (_midiInBuffers[i] != nullptr) {
@@ -119,12 +119,12 @@ class WindowsMidiDevice extends MidiDevice {
         }
       }
 
-      result = midiInStop(hMidiInDevicePtr.value);
+      result = midiInStop(hMidiInDevicePtr.value as HMIDIIN);
       if (result != 0) {
         print("STOP ERROR($result): ${midiErrorMessage(result)}");
       }
 
-      result = midiInClose(hMidiInDevicePtr.value);
+      result = midiInClose(hMidiInDevicePtr.value as HMIDIIN);
       if (result != 0) {
         print("CLOSE ERROR($result): ${midiErrorMessage(result)}");
       }
@@ -133,7 +133,7 @@ class WindowsMidiDevice extends MidiDevice {
     }
 
     if (_outs.length > 0) {
-      result = midiOutClose(hMidiOutDevicePtr.value);
+      result = midiOutClose(hMidiOutDevicePtr.value as HMIDIOUT);
       if (result != 0) {
         print("OUT CLOSE ERROR($result): ${midiErrorMessage(result)}");
       }
@@ -160,7 +160,7 @@ class WindowsMidiDevice extends MidiDevice {
   containsMidiIn(int input) => hMidiInDevicePtr.value == input;
 
   _resetHeader(Pointer<MIDIHDR> midiHdrPointer) {
-    midiInAddBuffer(hMidiInDevicePtr.value, midiHdrPointer, sizeOf<MIDIHDR>());
+    midiInAddBuffer(hMidiInDevicePtr.value as HMIDIIN, midiHdrPointer, sizeOf<MIDIHDR>());
   }
 
   handleData(Uint8List data, int timestamp) {
@@ -177,25 +177,25 @@ class WindowsMidiDevice extends MidiDevice {
   send(Uint8List data) async {
     // Set data in out buffer
     _midiOutBuffer.asTypedList(data.length).setAll(0, data);
-    _midiOutHeader.ref.lpData = _midiOutBuffer as LPSTR;
+    _midiOutHeader.ref.lpData = _midiOutBuffer as PSTR;
     _midiOutHeader.ref.dwBytesRecorded =
         _midiOutHeader.ref.dwBufferLength = data.length;
     _midiOutHeader.ref.dwFlags = 0;
 
     int result = midiOutPrepareHeader(
-        hMidiOutDevicePtr.value, _midiOutHeader, sizeOf<MIDIHDR>());
+        hMidiOutDevicePtr.value as HMIDIOUT, _midiOutHeader, sizeOf<MIDIHDR>());
     if (result != 0) {
       print("HDR OUT PREP ERROR: ${midiErrorMessage(result)}");
     }
 
     result = midiOutLongMsg(
-        hMidiOutDevicePtr.value, _midiOutHeader, sizeOf<MIDIHDR>());
+        hMidiOutDevicePtr.value as HMIDIOUT, _midiOutHeader, sizeOf<MIDIHDR>());
     if (result != 0) {
       print("SEND ERROR($result): ${midiErrorMessage(result)}");
     }
 
     result = midiOutUnprepareHeader(
-        hMidiOutDevicePtr.value, _midiOutHeader, sizeOf<MIDIHDR>());
+        hMidiOutDevicePtr.value as HMIDIOUT, _midiOutHeader, sizeOf<MIDIHDR>());
     if (result != 0) {
       print("OUT UNPREPARE ERROR($result): ${midiErrorMessage(result)}");
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,18 @@
 name: flutter_midi_command_windows
 description: FlutterMidiCommand for windows.
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_midi_command_platform_interface: ^0.4.3
   ffi: ^2.1.4
-  win32: ^5.14.0
+  win32: ^6.2.0
   universal_ble: ^0.21.0
   device_manager: ^0.0.7
 


### PR DESCRIPTION
In order to be able to upgrade important packages from applications, such as device_info_plus, package_info_plus, wakelock_plus, share_plus, we need to be able to use package win32 >= 6.2.0

This PR mainly changes win32 from v5 to v6.

I tested MIDI input and output with virtual devices, and with a keyboard connected through universal_ble.

Another PR will concert flutter_midi_command to upgrade file_picker to a newer version which will use win32>=6.2.0

universal_ble will be upgraded in a distinct PR.